### PR TITLE
automatic path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ FD  = $(RES)/t1$(FONTBASE).fd
 
 # PREFIX = /usr/share/texmf-texlive
 # automatically get directory path
-PREFIX = $(shell kpsewhich -var-value TEXMFLOCAL)
+PREFIX = $(shell kpsewhich -var-value TEXMFDIST)
 
 TFMDIR = fonts/tfm/$(FONTBASE)
 AFMDIR = fonts/afm/$(FONTBASE)

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,9 @@ FD  = $(RES)/t1$(FONTBASE).fd
 ## Installation targets
 #
 
-PREFIX = /usr/share/texmf-texlive
+# PREFIX = /usr/share/texmf-texlive
+# automatically get directory path
+PREFIX = $(shell kpsewhich -var-value TEXMFLOCAL)
 
 TFMDIR = fonts/tfm/$(FONTBASE)
 AFMDIR = fonts/afm/$(FONTBASE)


### PR DESCRIPTION
The makefile will automatically determine the right font path by using the command "kpsewhich -var-value TEXMFLOCAL".

I tried it on mac and it workd. 
